### PR TITLE
feat: Todo編集機能を追加し、詳細表示を改善

### DIFF
--- a/back/app/controllers/todos_controller.rb
+++ b/back/app/controllers/todos_controller.rb
@@ -27,6 +27,7 @@ class TodosController < ApplicationController
 
   # PATCH/PUT /todos/1
   def update
+    @todo = Todo.find(params[:id])
     if @todo.update(todo_params)
       render json: @todo
     else

--- a/front/src/app/todos/[id]/edit/page.tsx
+++ b/front/src/app/todos/[id]/edit/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+export default function Page() {
+  const currentPath = usePathname();
+  const id = currentPath.split("/")[2];
+  console.log(id);
+  const [title, setTitle] = useState<string>("");
+  const [content, setContent] = useState<string>("");
+  const router = useRouter();
+
+  useEffect(() => {
+  const fetchTodo = async () => {
+    const response = await fetch(`http://localhost:3000/todos/${id}`);
+    const todo = await response.json();
+    setTitle(todo.title);
+    setContent(todo.content);
+  }
+    if (id) {
+      fetchTodo();
+    }
+  }, [id]);
+  
+  const handleEditForm = () => {
+    // e.preventDefault();
+    fetch(`http://localhost:3000/todos/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: title,
+        content: content,
+      }),
+    });
+    router.push(`/todos`);
+  }
+
+  return (
+    <div>
+      <form onSubmit={handleEditForm}>
+        <label htmlFor="title">title</label>
+        <input
+          onChange={(e) => setTitle(e.target.value)}
+          type="text"
+          name="title"
+          id="title"
+          value={title}
+          className=""
+        />
+        <label htmlFor="context">Content</label>
+        <textarea
+          onChange={(e) => setContent(e.target.value)}
+          name="context"
+          id="context"
+          value={content}>
+        </textarea>
+        <button type="submit">編集</button>
+      </form>
+    </div>
+  );
+}

--- a/front/src/app/todos/[id]/page.tsx
+++ b/front/src/app/todos/[id]/page.tsx
@@ -2,15 +2,17 @@
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Todo } from "@/types/Todo";
+import Link from "next/link";
 
 export default function Page() { 
   const currentPath = usePathname();
   const id = currentPath.split("/")[2];
-  const [todo, setTodos] = useState<Todo | null>(null);
+  const [todo, setTodo] = useState<Todo | null>(null);
+
   const fetchTodos = async () => {
-    const response = await fetch(`http://localhost:3000/todos/${id}`);
-    const todo: Todo = await response.json();
-    setTodos(todo);
+    const res = await fetch(`http://localhost:3000/todos/${id}`);
+    const todo = await res.json();
+    setTodo(todo);
   } 
   useEffect(() => { 
     fetchTodos();
@@ -18,6 +20,8 @@ export default function Page() {
   return (
     <div>
       {todo?.title}
+      {todo?.content}
+      <Link href={`/todos/${id}/edit`}>編集</Link>
     </div>
   );
 }

--- a/front/src/types/Todo.ts
+++ b/front/src/types/Todo.ts
@@ -1,5 +1,5 @@
 export type Todo = {
   id: number;
   title: string;
-  context: string;
+  content: string;
 }


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend components of the application to improve the handling and display of "Todo" items. The most important changes include updating the `update` method in the `TodosController` on the backend, adding an edit page for "Todo" items on the frontend, and correcting a typo in the `Todo` type definition.

Backend changes:

* [`back/app/controllers/todos_controller.rb`](diffhunk://#diff-bd6c11e8e50bc5cf5f604af56e5f6ea5340e59cb5a1562b938fbda13b43b53b6R30): Updated the `update` method to find the `Todo` item by its ID before updating it.

Frontend changes:

* `front/src/app/todos/[id]/edit/page.tsx`: Added a new edit page that fetches the "Todo" item by ID, allows the user to edit it, and submits the changes via a PUT request. ([front/src/app/todos/[id]/edit/page.tsxR1-R63](diffhunk://#diff-ccb1892eb5868372ca592cac169cf6af65869f8ae7459cc7f2142e83b0ca9856R1-R63))
* `front/src/app/todos/[id]/page.tsx`: Added a link to the edit page and displayed the "Todo" item's content. ([front/src/app/todos/[id]/page.tsxR5-R24](diffhunk://#diff-032acbd4b7ab8a39580bd2e1892ea4e3ad3f7bafd47f0d07aec05df27ac52096R5-R24))
* [`front/src/types/Todo.ts`](diffhunk://#diff-c21e1d09b8ceddabd365265a37a6235b14752b36e925e62c10ff4131be77b56eL4-R4): Corrected the typo in the `Todo` type definition by changing the property name from `context` to `content`.